### PR TITLE
updated the links in adoption page to go both to the instructions and the forms themselves based on client feedback

### DIFF
--- a/_pages/worldwide-adoption.md
+++ b/_pages/worldwide-adoption.md
@@ -11,7 +11,7 @@ locations_orgs:
     These countries and regions have implemented International Patient Access (IPA) using the HL7 FHIR standard, enabling cross-border health data access.
 
     **Submit Your Location**\
-    Do you represent a health care organization, government agency, laboratory, pharmacy or payor? Learn more about [submitting your organization](https://github.com/HL7/ipa-website/blob/main/README.md#organization-listing){: target="_blank"} for listing.
+    Do you represent a health care organization, government agency, laboratory, pharmacy or payor? Learn more about [listing your organization](https://github.com/HL7/ipa-website/blob/main/README.md){: target="_blank"} and filling out a [submission form](https://docs.google.com/forms/d/e/1FAIpQLSddDFt9G5dLr6emaNNBSosc4oHpJqA5ZBKmOY58-buILMZ8nw/viewform){: target="_blank}.
   show_map: true
 
 # Apps List
@@ -20,7 +20,7 @@ locations_apps:
   subheading: "Health IT patient-facing apps supporting IPA standards."
   description: |
     **Submit your App**\
-    Are you a developer of a patient-facing health IT app that supports HL7 FHIR International Patient Access (IPA) standards? Submit your application to be featured in our directory by understanding the requirements and filling out our [submission form](https://github.com/HL7/ipa-website/blob/main/README.md#app-listing){: target="_blank"}.
+    Are you a developer of a patient-facing health IT app that supports HL7 FHIR International Patient Access (IPA) standards? Submit your application to be featured in our directory by [understanding the requirements](https://github.com/HL7/ipa-website/blob/main/README.md){: target="_blank"} and filling out our [submission form](https://docs.google.com/forms/d/e/1FAIpQLSeGGNNW8zItp5-uapxCA3RIDWJefHCfWuUTaRmHUWRgh4q2Mg/viewform){: target="_blank}.
 
     Disclaimer: The inclusion of apps in this directory is not an endorsement by Health Level Seven International (HL7). Users should verify the suitability of each app for their specific needs.
 


### PR DESCRIPTION
## What Type of Change is This?
- [ ] 🐛 Bug fix
- [X] ✨ Introduced New Features
- [ ] 🔌 Plugin Updates
- [ ] 🚑 Critical Hotfix
- [ ] ♻️ Change or Refactor to Existing Feature
- [ ] 🤕 Patch Fix
- [ ] 🔒️ Security Updates
- [ ] 👷 Deploy/Build System
- [ ] 🔊 Add Logging
- [ ] 🧟‍♂️ Remove Dead Code
- [ ] 📸 Capturing Uncommitted Code 

---

Client feedback: I would expect the link to “submission form” would take me directly to the form. It’s hard to find the form link when I’m taken to the GitHub page. Perhaps we could include two links on this page: one to the instructions, and another one to the form?





---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```



