### PR TITLE
change site title from Argonaut to IPA

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@
 # in the templates via {{ site.myvariable }}.
 
 title:
-  en: Argonaut
-  de: Argonaut (DE)
+  en: International Patient Access
+  de: International Patient Access (DE)
 email: your-email@example.com
 description:
   en: International Patient Access empowers patients with secure, global access to their health records using the HL7 FHIR specification, enhancing healthcare delivery and interoperability across borders. Learn about best practices and steps to implement effective health data solutions.

--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@
 # in the templates via {{ site.myvariable }}.
 
 title:
-  en: International Patient Access
-  de: International Patient Access (DE)
+  en: International Patient Access - IPA
+  de: International Patient Access - IPA (DE)
 email: your-email@example.com
 description:
   en: International Patient Access empowers patients with secure, global access to their health records using the HL7 FHIR specification, enhancing healthcare delivery and interoperability across borders. Learn about best practices and steps to implement effective health data solutions.


### PR DESCRIPTION
Use english for both german and english site.

![image](https://github.com/user-attachments/assets/e870dfee-7ef4-42c8-b4a5-dcfc3cf662d3)
